### PR TITLE
Ignore vars properly

### DIFF
--- a/.changeset/fuzzy-apes-bake.md
+++ b/.changeset/fuzzy-apes-bake.md
@@ -1,0 +1,7 @@
+---
+'eslint-config-widen': patch
+---
+
+Ignore unused variables in destructuring patterns when they start with an
+underscore. This has worked historically for JavaScript, but it was not working
+properly in TypeScript files.

--- a/packages/eslint-config-widen/src/typescript.ts
+++ b/packages/eslint-config-widen/src/typescript.ts
@@ -19,7 +19,8 @@ export = {
         '@typescript-eslint/no-unused-vars': [
           'error',
           {
-            argsIgnorePattern: '^_',
+            ignoreRestSiblings: true,
+            varsIgnorePattern: '^_',
           },
         ],
         '@typescript-eslint/no-var-requires': 'off',


### PR DESCRIPTION
Get's the TypeScript ignored vars config in line with the current JavaScript config.