### PR TITLE
Add Playwright config

### DIFF
--- a/.changeset/silly-starfishes-exercise.md
+++ b/.changeset/silly-starfishes-exercise.md
@@ -1,0 +1,6 @@
+---
+'eslint-config-widen': minor
+---
+
+Add `widen/playwright` config to allow easily configuring the Playwright ESLint
+config.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Widen's shared ESLint config and plugins.
 
 ## Installation
 
-```sh
+```bash
 yarn add -D eslint eslint-{config,plugin}-widen eslint-plugin-sort @babel/{core,eslint-parser}
 
 # If you use TypeScript
@@ -15,6 +15,9 @@ yarn add -D @typescript-eslint/{eslint-plugin,parser}
 
 # If you use React
 yarn add -D eslint-plugin-{react,react-hooks,jsx-a11y}
+
+# If you use Playwright
+yarn add -D eslint-plugin-playwright
 
 # If you use Jest
 yarn add -D eslint-plugin-jest
@@ -27,6 +30,16 @@ If you don't need a specific configuration, simply remove it from the list.
 
 ```json
 {
-  "extends": ["widen", "widen/typescript", "widen/react", "widen/jest"]
+  "extends": ["widen", "widen/typescript", "widen/react"],
+  "overrides": [
+    {
+      "files": ["e2e/**"],
+      "extends": "widen/playwright"
+    },
+    {
+      "files": ["frontend/**/*.spec.js"],
+      "extends": "widen/jest"
+    }
+  ]
 }
 ```

--- a/packages/eslint-config-widen/README.md
+++ b/packages/eslint-config-widen/README.md
@@ -4,7 +4,7 @@ Widen's shared ESLint config.
 
 ## Installation
 
-```sh
+```bash
 yarn add -D eslint eslint-{config,plugin}-widen eslint-plugin-sort @babel/{core,eslint-parser}
 
 # If you use TypeScript
@@ -12,6 +12,9 @@ yarn add -D @typescript-eslint/{eslint-plugin,parser}
 
 # If you use React
 yarn add -D eslint-plugin-{react,react-hooks,jsx-a11y}
+
+# If you use Playwright
+yarn add -D eslint-plugin-playwright
 
 # If you use Jest
 yarn add -D eslint-plugin-jest
@@ -24,6 +27,16 @@ If you don't need a specific configuration, simply remove it from the list.
 
 ```json
 {
-  "extends": ["widen", "widen/typescript", "widen/react", "widen/jest"]
+  "extends": ["widen", "widen/typescript", "widen/react"],
+  "overrides": [
+    {
+      "files": ["e2e/**"],
+      "extends": "widen/playwright"
+    },
+    {
+      "files": ["frontend/**/*.spec.js"],
+      "extends": "widen/jest"
+    }
+  ]
 }
 ```

--- a/packages/eslint-config-widen/package.json
+++ b/packages/eslint-config-widen/package.json
@@ -16,6 +16,7 @@
   "exports": {
     ".": "./lib/index.js",
     "./jest": "./lib/jest.js",
+    "./playwright": "./lib/playwright.js",
     "./react": "./lib/react.js",
     "./typescript": "./lib/typescript.js"
   },
@@ -29,6 +30,7 @@
     "eslint": ">= 8",
     "eslint-plugin-jest": ">= 25",
     "eslint-plugin-jsx-a11y": ">= 6",
+    "eslint-plugin-playwright": ">=0.10.0",
     "eslint-plugin-react": ">= 7",
     "eslint-plugin-react-hooks": ">= 4",
     "eslint-plugin-sort": ">= 2",
@@ -45,6 +47,9 @@
       "optional": true
     },
     "eslint-plugin-jsx-a11y": {
+      "optional": true
+    },
+    "eslint-plugin-playwright": {
       "optional": true
     },
     "eslint-plugin-react": {

--- a/packages/eslint-config-widen/src/playwright.ts
+++ b/packages/eslint-config-widen/src/playwright.ts
@@ -1,0 +1,16 @@
+export = {
+  overrides: [
+    {
+      extends: ['plugin:playwright/playwright-test'],
+      plugins: ['playwright'],
+      rules: {
+        // TODO: Uncomment when these rules are released
+        // 'playwright/prefer-lowercase-title': [
+        //   'warn',
+        //   { ignoreTopLevelDescribe: true },
+        // ],
+        // 'playwright/require-top-level-describe': 'warn',
+      },
+    },
+  ],
+}

--- a/packages/eslint-plugin-widen/README.md
+++ b/packages/eslint-plugin-widen/README.md
@@ -6,7 +6,7 @@ Widen's own ESLint plugin containing custom lint rules for our code.
 
 ## Installation
 
-```sh
+```bash
 yarn add --dev eslint-plugin-widen
 ```
 

--- a/packages/eslint-plugin-widen/docs/jsx-fragments.md
+++ b/packages/eslint-plugin-widen/docs/jsx-fragments.md
@@ -9,7 +9,7 @@ Enforce usage of JSX fragment longhand to allow for compatibility with Emotion.
 
 Example of **incorrect** code for this rule:
 
-```js
+```javascript
 /** @jsx jsx */
 import { jsx } from '@emotion/react'
 
@@ -20,7 +20,7 @@ function MyComponent() {
 
 Example of **correct** code for this rule:
 
-```js
+```javascript
 /** @jsx jsx */
 import { jsx } from '@emotion/react'
 import { useEffect, Fragment } from 'react'

--- a/packages/eslint-plugin-widen/docs/jsx-import.md
+++ b/packages/eslint-plugin-widen/docs/jsx-import.md
@@ -15,7 +15,7 @@ Enforces all files to use the `jsx` pragma from `@emotion/react` when using the
 
 Example of **incorrect** code for this rule:
 
-```js
+```javascript
 import { css } from '@emotion/react'
 import React from 'react'
 
@@ -30,7 +30,7 @@ function MyComponent() {
 
 Example of **correct** code for this rule:
 
-```js
+```javascript
 /** @jsx jsx */
 import { css, jsx } from '@emotion/react'
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3852,6 +3852,7 @@ __metadata:
     eslint: ">= 8"
     eslint-plugin-jest: ">= 25"
     eslint-plugin-jsx-a11y: ">= 6"
+    eslint-plugin-playwright: ">=0.10.0"
     eslint-plugin-react: ">= 7"
     eslint-plugin-react-hooks: ">= 4"
     eslint-plugin-sort: ">= 2"
@@ -3864,6 +3865,8 @@ __metadata:
     eslint-plugin-jest:
       optional: true
     eslint-plugin-jsx-a11y:
+      optional: true
+    eslint-plugin-playwright:
       optional: true
     eslint-plugin-react:
       optional: true


### PR DESCRIPTION
Adds a new `widen/playwright` config to easily pull in the Playwright ESLint plugin.  Getting this added now as soon we'll be needing to add some custom rule config which we want to do globally for all apps.