### PR TITLE
Fix Playwright config

### DIFF
--- a/.changeset/flat-falcons-drop.md
+++ b/.changeset/flat-falcons-drop.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-widen': patch
+---
+
+Remove `overrides` from `widen/playwright` configuration which was incorrect.

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ If you don't need a specific configuration, simply remove it from the list.
       "extends": "widen/playwright"
     },
     {
-      "files": ["frontend/**/*.spec.js"],
+      "files": ["frontend/**"],
       "extends": "widen/jest"
     }
   ]

--- a/packages/eslint-config-widen/src/playwright.ts
+++ b/packages/eslint-config-widen/src/playwright.ts
@@ -1,16 +1,12 @@
 export = {
-  overrides: [
-    {
-      extends: ['plugin:playwright/playwright-test'],
-      plugins: ['playwright'],
-      rules: {
-        'playwright/prefer-lowercase-title': [
-          'warn',
-          { ignoreTopLevelDescribe: true },
-        ],
-        'playwright/prefer-to-have-length': 'warn',
-        'playwright/require-top-level-describe': 'warn',
-      },
-    },
-  ],
+  extends: ['plugin:playwright/playwright-test'],
+  plugins: ['playwright'],
+  rules: {
+    'playwright/prefer-lowercase-title': [
+      'warn',
+      { ignoreTopLevelDescribe: true },
+    ],
+    'playwright/prefer-to-have-length': 'warn',
+    'playwright/require-top-level-describe': 'warn',
+  },
 }


### PR DESCRIPTION
Fixes the Playwright configuration which I mistakenly copied over an `overrides` block which isn't what we want for the Playwright config.