### PR TITLE
remove specified registry

### DIFF
--- a/.changeset/strong-days-complain.md
+++ b/.changeset/strong-days-complain.md
@@ -1,0 +1,6 @@
+---
+'eslint-config-widen': patch
+'eslint-plugin-widen': patch
+---
+
+Remove npmRegistryServer

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,4 +5,3 @@ plugins:
     spec: "https://mskelton.dev/yarn-outdated/v3"
 
 yarnPath: .yarn/releases/yarn-3.2.1.cjs
-npmRegistryServer: "https://registry.npmjs.org/"


### PR DESCRIPTION
With the added registry, we were not seeing the latest release published to our internal registry.
