### PR TITLE
Correctly specify react version and fix typescript overrides.

### DIFF
--- a/.changeset/happy-moose-care.md
+++ b/.changeset/happy-moose-care.md
@@ -1,0 +1,6 @@
+---
+'eslint-config-widen': patch
+'eslint-playground': patch
+---
+
+Correctly specify react version and fix typescript overrides.

--- a/packages/eslint-config-widen/src/react.ts
+++ b/packages/eslint-config-widen/src/react.ts
@@ -12,6 +12,14 @@ const languageOptions = {
   },
 }
 
+const reactVersion = {
+  settings: {
+    react: {
+      version: 'detect',
+    },
+  },
+}
+
 export default [
   {
     files: ['**/*.{js,jsx,mjs,cjs,ts,tsx}'],
@@ -22,6 +30,7 @@ export default [
     rules: {
       ...react.configs.recommended.rules,
     },
+    ...reactVersion,
   },
   {
     files: ['**/*.{js,jsx,mjs,cjs,ts,tsx}'],
@@ -101,11 +110,6 @@ export default [
       ],
       'widen/jsx-fragments': 'error',
       'widen/jsx-import': 'error',
-    },
-    settings: {
-      react: {
-        version: 'detect',
-      },
     },
   },
 ]

--- a/packages/eslint-config-widen/src/typescript.ts
+++ b/packages/eslint-config-widen/src/typescript.ts
@@ -3,7 +3,6 @@ import { configs, parser, plugin } from 'typescript-eslint'
 export default [
   ...configs.recommended,
   {
-    files: ['*.ts', '*.tsx'],
     languageOptions: {
       parser: parser,
     },

--- a/packages/eslint-playground/reactTest.jsx
+++ b/packages/eslint-playground/reactTest.jsx
@@ -2,5 +2,10 @@ import React from 'react'
 
 export function test(unused, unused) {
   console.log('wow')
-  return <button>Test</button>
+  return (
+    <div>
+      <div children="Children" />
+      <button autoFocus={true}>Test</button>
+    </div>
+  )
 }


### PR DESCRIPTION
We were getting an error that the react version was not correctly specifies, this will fix that.  I also realized that our typescript overrides were only applying to specific file types and not everything like the configs.recommended does.