### PR TITLE
adjust package build order

### DIFF
--- a/.changeset/cyan-pigs-live.md
+++ b/.changeset/cyan-pigs-live.md
@@ -10,4 +10,4 @@
 'eslint-plugin-widen': patch
 ---
 
-Attempt to fix workspace dependecy issues.
+Attempt to fix workspace dependency issues.

--- a/.changeset/cyan-pigs-live.md
+++ b/.changeset/cyan-pigs-live.md
@@ -1,0 +1,13 @@
+---
+'eslint-config-widen': patch
+'eslint-config-widen-base': patch
+'eslint-config-widen-emotion': patch
+'eslint-config-widen-jest': patch
+'eslint-config-widen-playwright': patch
+'eslint-config-widen-react': patch
+'eslint-config-widen-typescript': patch
+'eslint-playground': patch
+'eslint-plugin-widen': patch
+---
+
+Attempt to fix workspace dependecy issues.

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,13 +1,13 @@
 {
   "files": [],
   "references": [
-    { "path": "packages/eslint-config-widen" },
     { "path": "packages/eslint-config-widen-base" },
     { "path": "packages/eslint-config-widen-emotion" },
     { "path": "packages/eslint-config-widen-jest" },
     { "path": "packages/eslint-config-widen-playwright" },
     { "path": "packages/eslint-config-widen-react" },
     { "path": "packages/eslint-config-widen-typescript" },
-    { "path": "packages/eslint-plugin-widen" }
+    { "path": "packages/eslint-plugin-widen" },
+    { "path": "packages/eslint-config-widen" }
   ]
 }


### PR DESCRIPTION
This pull request includes a change to the `.changeset/cyan-pigs-live.md` file to address workspace dependency issues. The change specifies patch updates for several ESLint configurations and plugins.

* [`.changeset/cyan-pigs-live.md`](diffhunk://#diff-175e8eb3ce9bc988f8d3d89c7500f297492c52e2e7f73ac90c69e45526749ae9R1-R13): Added patch updates for `eslint-config-widen`, `eslint-config-widen-base`, `eslint-config-widen-emotion`, `eslint-config-widen-jest`, `eslint-config-widen-playwright`, `eslint-config-widen-react`, `eslint-config-widen-typescript`, `eslint-playground`, and `eslint-plugin-widen`.
