### PR TITLE
Fix dependency versions in ESLint config package

### DIFF
--- a/.changeset/flat-dodos-tan.md
+++ b/.changeset/flat-dodos-tan.md
@@ -1,0 +1,5 @@
+---
+'eslint-config-widen': patch
+---
+
+Fix dependency versions.

--- a/packages/eslint-config-widen/package.json
+++ b/packages/eslint-config-widen/package.json
@@ -2,11 +2,11 @@
   "author": "Widen",
   "dependencies": {
     "eslint-config-prettier": "^9.1.0",
-    "eslint-config-widen-base": "workspace:^",
-    "eslint-config-widen-jest": "workspace:^",
-    "eslint-config-widen-playwright": "workspace:^",
-    "eslint-config-widen-react": "workspace:^",
-    "eslint-config-widen-typescript": "workspace:^"
+    "eslint-config-widen-base": "^4.0.1",
+    "eslint-config-widen-jest": "^2.2.1",
+    "eslint-config-widen-playwright": "^2.2.1",
+    "eslint-config-widen-react": "^2.2.1",
+    "eslint-config-widen-typescript": "^2.2.1"
   },
   "description": "Widen's shared ESLint config.",
   "exports": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3691,7 +3691,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"eslint-config-widen-base@workspace:^, eslint-config-widen-base@workspace:packages/eslint-config-widen-base":
+"eslint-config-widen-base@npm:^4.0.1, eslint-config-widen-base@workspace:packages/eslint-config-widen-base":
   version: 0.0.0-use.local
   resolution: "eslint-config-widen-base@workspace:packages/eslint-config-widen-base"
   dependencies:
@@ -3714,7 +3714,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"eslint-config-widen-jest@workspace:^, eslint-config-widen-jest@workspace:packages/eslint-config-widen-jest":
+"eslint-config-widen-jest@npm:^2.2.1, eslint-config-widen-jest@workspace:packages/eslint-config-widen-jest":
   version: 0.0.0-use.local
   resolution: "eslint-config-widen-jest@workspace:packages/eslint-config-widen-jest"
   dependencies:
@@ -3725,7 +3725,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"eslint-config-widen-playwright@workspace:^, eslint-config-widen-playwright@workspace:packages/eslint-config-widen-playwright":
+"eslint-config-widen-playwright@npm:^2.2.1, eslint-config-widen-playwright@workspace:packages/eslint-config-widen-playwright":
   version: 0.0.0-use.local
   resolution: "eslint-config-widen-playwright@workspace:packages/eslint-config-widen-playwright"
   dependencies:
@@ -3736,7 +3736,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"eslint-config-widen-react@workspace:^, eslint-config-widen-react@workspace:packages/eslint-config-widen-react":
+"eslint-config-widen-react@npm:^2.2.1, eslint-config-widen-react@workspace:packages/eslint-config-widen-react":
   version: 0.0.0-use.local
   resolution: "eslint-config-widen-react@workspace:packages/eslint-config-widen-react"
   dependencies:
@@ -3749,7 +3749,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"eslint-config-widen-typescript@workspace:^, eslint-config-widen-typescript@workspace:packages/eslint-config-widen-typescript":
+"eslint-config-widen-typescript@npm:^2.2.1, eslint-config-widen-typescript@workspace:packages/eslint-config-widen-typescript":
   version: 0.0.0-use.local
   resolution: "eslint-config-widen-typescript@workspace:packages/eslint-config-widen-typescript"
   dependencies:
@@ -3766,11 +3766,11 @@ __metadata:
   resolution: "eslint-config-widen@workspace:packages/eslint-config-widen"
   dependencies:
     eslint-config-prettier: "npm:^9.1.0"
-    eslint-config-widen-base: "workspace:^"
-    eslint-config-widen-jest: "workspace:^"
-    eslint-config-widen-playwright: "workspace:^"
-    eslint-config-widen-react: "workspace:^"
-    eslint-config-widen-typescript: "workspace:^"
+    eslint-config-widen-base: "npm:^4.0.1"
+    eslint-config-widen-jest: "npm:^2.2.1"
+    eslint-config-widen-playwright: "npm:^2.2.1"
+    eslint-config-widen-react: "npm:^2.2.1"
+    eslint-config-widen-typescript: "npm:^2.2.1"
   peerDependencies:
     "@babel/eslint-parser": ^7.22.15
     eslint: ">= 9"


### PR DESCRIPTION
This pull request includes updates to the `eslint-config-widen` package to fix dependency versions. The changes involve modifying the dependency versions to specific versions instead of using workspace ranges.

Dependency version fixes:

* [`.changeset/flat-dodos-tan.md`](diffhunk://#diff-617cf8ebacb0826312b301aedfd4b5046cc9e0629202db0ff44c995ba88ccc35R1-R5): Added a changeset file to document the patch update for fixing dependency versions.
* [`packages/eslint-config-widen/package.json`](diffhunk://#diff-12f5f8b940fdc1a4f283a772bcd7161451778b392d47e8bd84b7c8bae434941eL5-R9): Updated the versions of `eslint-config-widen-base`, `eslint-config-widen-jest`, `eslint-config-widen-playwright`, `eslint-config-widen-react`, and `eslint-config-widen-typescript` to specific versions.
