### PR TITLE
add prerelease

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -67,9 +67,7 @@ jobs:
         run: yarn build
 
       - name: Publish Pre-release
-        run:
-          yarn changeset publish --tag ${{ github.event.inputs.preid || 'beta'
-          }}
+        run: yarn changeset publish --tag ${{ github.event.inputs.preid || 'beta' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,0 +1,80 @@
+name: Pre-release
+on:
+  push:
+    branches:
+      - beta # or any branch you want to trigger pre-releases from
+  workflow_dispatch:
+    inputs:
+      preid:
+        description: 'Pre-release identifier (e.g., beta, alpha)'
+        required: true
+        default: 'beta'
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+          cache: yarn
+      - run: yarn install --immutable
+      - run: yarn lint
+      - run: yarn prettier --check .
+      - run: yarn tsc
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: yarn
+      - run: yarn install --immutable
+      - run: yarn test
+  prerelease:
+    name: Create Pre-release
+    runs-on: ubuntu-latest
+    needs: [lint, test]
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: yarn
+
+      - name: Install Dependencies
+        run: yarn install --immutable
+
+      - name: Create Pre-release
+        run: |
+          yarn changeset pre enter ${{ github.event.inputs.preid || 'beta' }}
+          yarn changeset version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        run: yarn build
+
+      - name: Publish Pre-release
+        run:
+          yarn changeset publish --tag ${{ github.event.inputs.preid || 'beta'
+          }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Exit Pre-release Mode
+        run: yarn changeset pre exit
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -67,7 +67,8 @@ jobs:
         run: yarn build
 
       - name: Publish Pre-release
-        run: yarn changeset publish --tag ${{ github.event.inputs.preid || 'beta' }}
+        run: |
+          yarn changeset publish --tag ${{ github.event.inputs.preid || 'beta' }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Adding a pre-release step.

General expected workflow:

**Step 1: Create a Branch and Push Changes**

- Create a branch (e.g., feature/my-feature) and add a changeset.
- Push the branch to GitHub.

**Step 2: Run the Pre-release Workflow Manually**

Manually trigger the prerelease.yml workflow via GitHub Actions.

**The workflow:**
- Enters pre-release mode (yarn changeset pre enter beta).
- Versions the packages with a pre-release identifier (e.g., 1.0.0-beta.0).
- Builds and publishes the pre-release to npm with the beta tag.
- Exits pre-release mode (yarn changeset pre exit).
- At this point, the pre-release version (e.g., 1.0.0-beta.0) is available for testing.

**Making Further Changes**

If making additional changes to the same branch:

- Add a new changeset for the changes.
- Push the changes to your branch.
- Manually re-run the prerelease.yml workflow.

**What Happens When You Re-run the Workflow?**

The workflow will re-enter pre-release mode (yarn changeset pre enter beta).
Changesets will detect the new changes and increment the pre-release version (e.g., 1.0.0-beta.1, 1.0.0-beta.2, etc.).
The updated pre-release version will be published to npm with the beta tag.
Pre-release versions are incremental, so each new run will create a new version (e.g., 1.0.0-beta.1, 1.0.0-beta.2, etc.), allowing you to test each iteration.

**3. Merging to Main**

Once satisfied with the pre-release and testing is complete:

Merge branch into main.
The normal release workflow (e.g., release.yml) will run automatically.

What Happens on Main?

Changesets will detect all the changesets in the branch and calculate the next stable version (e.g., 1.0.0 or 1.1.0).
The stable version will be published without the pre-release identifier (e.g., beta).

**Key Points to Note**

Pre-release Versions Are Incremental:

- Each time you re-run the pre-release workflow, the pre-release version will increment (e.g., 1.0.0-beta.0, 1.0.0-beta.1, etc.).
- This allows you to test multiple iterations of your changes.

Exiting Pre-release Mode:

- The yarn changeset pre exit step ensures that the repository is no longer in pre-release mode after the workflow completes.
- If you want to continue working on pre-releases, you must re-enter pre-release mode manually by re-running the workflow.

Stable Release After Merge:

When you merge to main, the stable release workflow will calculate the next stable version and publish it (e.g., 1.0.0).

Pre-release Tags:

Pre-releases are published with a specific tag (e.g., beta), so they do not interfere with the stable release line.
Users can install the pre-release version explicitly using the tag (e.g., npm install your-package@beta).

Example Workflow
Here’s how the process might look in practice:

Create a Branch:

Add a changeset and push the branch.
Run Pre-release Workflow:

Manually trigger the prerelease.yml workflow.
Pre-release version 1.0.0-beta.0 is published.

Make Additional Changes:

Add another changeset and push the branch.
Re-run the prerelease.yml workflow.
Pre-release version 1.0.0-beta.1 is published.

Merge to Main:

Merge the branch into main.
The stable release workflow runs and publishes version 1.0.0.
