### PR TITLE
point build to ts step

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -63,8 +63,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build
-        run: yarn build
+      - name: Build TS
+        run: yarn ts
 
       - name: Publish Pre-release
         run: |


### PR DESCRIPTION
`yarn build` doesn't exist as a script in package.json.
Should be `yarn ts` which runs `tsc -b`